### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [Win32, x64]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+    - name: Build
+      run: msbuild mimikatz.sln /m /p:Configuration=Release /p:Platform=${{ matrix.platform }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        name: mimikatz-${{ matrix.platform }}
+        path: ${{ matrix.platform }}/**/*


### PR DESCRIPTION
## Summary
- update GitHub Actions build workflow
  - use checkout `v4`
  - remove toolset argument from the build step
  - pin artifact action to version 3.1.3

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_683b01b50948832e9a7b9038abba2ff0