### PR TITLE
Fix artifact workflow path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [Win32, x64]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+    - name: Build
+      run: msbuild mimikatz.sln /m /p:Configuration=Release /p:Platform=${{ matrix.platform }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: mimikatz-${{ matrix.platform }}
+        path: ${{ matrix.platform }}/**/*


### PR DESCRIPTION
## Summary
- update to `actions/checkout@v4`
- remove explicit `PlatformToolset` from msbuild
- pin artifact step to `actions/upload-artifact@v3`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_683b01b50948832e9a7b9038abba2ff0