### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [Win32, x64]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+    - name: Build
+      run: msbuild mimikatz\mimikatz.vcxproj /m /p:Configuration=Release /p:Platform=${{ matrix.platform }} /p:PlatformToolset=v143
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mimikatz-${{ matrix.platform }}
+        path: ${{ matrix.platform }}/**/*


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build mimikatz
- fix workflow to use supported actions and compile main project only

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_683b01b50948832e9a7b9038abba2ff0